### PR TITLE
Disabled EnableNETAnalyzers and EnforceCodeStyleInBuild settings

### DIFF
--- a/Ngsa.DataAccessLayer/Ngsa.DataAccessLayer.csproj
+++ b/Ngsa.DataAccessLayer/Ngsa.DataAccessLayer.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
-	<EnableNETAnalyzers>true</EnableNETAnalyzers>
-	<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+	<EnableNETAnalyzers>false</EnableNETAnalyzers>
+	<EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ngsa.LodeRunner.csproj
+++ b/Ngsa.LodeRunner.csproj
@@ -13,8 +13,8 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
     <LangVersion>Latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
By disabling these flags the loderunner build should successfully complete 

Closes [Issue #329](https://github.com/retaildevcrews/wcnp/issues/329)