### PR TITLE
Fixed logic to correctly intercept Ctrl+C and OnAppClose events

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -45,6 +45,8 @@ namespace Ngsa.LodeRunner
         {
             cancelTokenSource = new CancellationTokenSource();
 
+            RegisterTerminationEvents();
+
             if (args != null)
             {
                 DisplayAsciiArt(args);
@@ -101,6 +103,26 @@ namespace Ngsa.LodeRunner
                         })
                         .UseConsoleLifetime()
                         .Build();
+        }
+
+        /// <summary>
+        /// Registers the termination events.
+        /// </summary>
+        private static void RegisterTerminationEvents()
+        {
+            AppDomain.CurrentDomain.ProcessExit += (s, ev) =>
+            {
+                if (!cancelTokenSource.IsCancellationRequested)
+                {
+                    cancelTokenSource.Cancel(false);
+                }
+            };
+
+            Console.CancelKeyPress += (_, e) =>
+            {
+                e.Cancel = true;
+                cancelTokenSource.Cancel(false);
+            };
         }
 
         // ascii art

--- a/src/core/Startup.cs
+++ b/src/core/Startup.cs
@@ -55,7 +55,7 @@ namespace Ngsa.LodeRunner
             // signal run loop
             life.ApplicationStopping.Register(() =>
             {
-                if (cancellationTokenSource != null)
+                if (cancellationTokenSource != null && !cancellationTokenSource.IsCancellationRequested)
                 {
                     cancellationTokenSource.Cancel(false); // TODO: Do we need to pass 'true' to throw and bubble up the exception?
                 }


### PR DESCRIPTION
Fixed logic to correctly intercept Ctrl+C and OnAppClose events to intiate Cancellation Token Request with out Windows Native dlls dependencies.

Testing 
- [x] Docker image built successfully (locally)
- [x] Docker image ran successfully (locally)
- [x] Ctl+C worked as expected for several scenarios,  for instance.
     -  delay-star = -1
     -  run-loop true
     -  delay-star = 5

Closes [issue #330](https://github.com/retaildevcrews/wcnp/issues/330)