### PR TITLE
Fix bug LodeRunner.API 500 when only required values are POSTed

### DIFF
--- a/src/LodeRunner.API/LodeRunnerApi.xml
+++ b/src/LodeRunner.API/LodeRunnerApi.xml
@@ -339,19 +339,21 @@
             Provides Extension methods for Models.
             </summary>
         </member>
-        <member name="M:LodeRunner.API.Middleware.ModelExtensions.Validate(LodeRunner.Core.Models.LoadTestConfig,System.String@)">
+        <member name="M:LodeRunner.API.Middleware.ModelExtensions.Validate(LodeRunner.Core.Models.LoadTestConfig,System.Collections.Generic.List{System.String},System.String@)">
             <summary>
-            Validates the specified load test configuration.
+            Validates the specified load test payload configuration.
             </summary>
             <param name="loadTestConfig">The load test configuration.</param>
+            <param name="payloadPropertiesChanged">Payload Properties Change list.</param>
             <param name="errorMessage">Error MEssage String if any.</param>
             <returns>Whether or not  the DTO passes validation.</returns>
         </member>
-        <member name="M:LodeRunner.API.Middleware.ModelExtensions.GetArgs(LodeRunner.Core.Models.LoadTestConfig)">
+        <member name="M:LodeRunner.API.Middleware.ModelExtensions.GetArgs(LodeRunner.Core.Models.LoadTestConfig,System.Collections.Generic.List{System.String})">
             <summary>
-            Gets the arguments.
+            Gets the arguments from properties that exist in changedProperties list.
             </summary>
             <param name="loadTestConfig">The load test configuration.</param>
+            <param name="payloadPropertiesChanged">Changed Properties list.</param>
             <returns>the args.</returns>
         </member>
         <member name="M:LodeRunner.API.Middleware.ModelExtensions.FieldValue(LodeRunner.Core.Models.LoadTestConfig,System.String)">

--- a/src/LodeRunner.API/src/Controllers/LoadTestConfigController.cs
+++ b/src/LodeRunner.API/src/Controllers/LoadTestConfigController.cs
@@ -56,7 +56,7 @@ namespace LodeRunner.API.Controllers
             // NOTE: the Mapping configuration will create a new loadTestConfig but will ignore the Id since the property has a getter and setter.
             LoadTestConfig newloadTestConfig = this.autoMapper.Map<LoadTestConfig>(loadTestConfigPayload);
 
-            if (newloadTestConfig.Validate(out string errorMessage))
+            if (newloadTestConfig.Validate(loadTestConfigPayload.PropertiesChanged, out string errorMessage))
             {
                 var insertedLoadTestConfig = await loadTestConfigService.Post(newloadTestConfig, cancellationTokenSource.Token);
 

--- a/src/LodeRunner.Core/CommandLine/LRCommandLine.cs
+++ b/src/LodeRunner.Core/CommandLine/LRCommandLine.cs
@@ -215,8 +215,19 @@ namespace LodeRunner.Core.CommandLine
             OptionResult randomRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "random") as OptionResult;
 
             bool runLoop = runLoopRes.GetValueOrDefault<bool>();
-            int? duration = durationRes.GetValueOrDefault<int?>();
             bool random = randomRes.GetValueOrDefault<bool>();
+
+            int? duration = null;
+            try
+            {
+                duration = durationRes.GetValueOrDefault<int?>();
+            }
+            catch
+            {
+                // let system.commandline.parser handle the error
+                // This implementation match webvalidate implementation in CommandLine.cs.
+                // What happens is that when a integer type parameter such as duration is not provided and we try to get the value utilizing method GetValueOrDefault. it throws an exception.
+            }
 
             if (duration != null && duration > 0 && !runLoop)
             {

--- a/src/LodeRunner.Core/LodeRunner.Core.xml
+++ b/src/LodeRunner.Core/LodeRunner.Core.xml
@@ -1021,6 +1021,131 @@
             LoadRestConfig Payload.
             </summary>
         </member>
+        <member name="E:LodeRunner.Core.Models.LoadTestConfigPayload.PropertyChanged">
+            <summary>
+            Occurs when a property value changes.
+            </summary>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.PropertiesChanged">
+            <summary>
+            Gets or sets the properties changed list.
+            </summary>
+            <value>
+            The changed properties.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.Files">
+            <summary>
+            Gets or sets the files.
+            </summary>
+            <value>
+            The files.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.StrictJson">
+            <summary>
+            Gets or sets a value indicating whether [strict json].
+            </summary>
+            <value>
+              <c>true</c> if [strict json]; otherwise, <c>false</c>.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.BaseURL">
+            <summary>
+            Gets or sets the base URL.
+            </summary>
+            <value>
+            The base URL.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.VerboseErrors">
+            <summary>
+            Gets or sets a value indicating whether [verbose errors].
+            </summary>
+            <value>
+              <c>true</c> if [verbose errors]; otherwise, <c>false</c>.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.Randomize">
+            <summary>
+            Gets or sets a value indicating whether this <see cref="T:LodeRunner.Core.Models.LoadTestConfig"/> is randomize.
+            </summary>
+            <value>
+              <c>true</c> if randomize; otherwise, <c>false</c>.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.Timeout">
+            <summary>
+            Gets or sets the timeout.
+            </summary>
+            <value>
+            The timeout.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.Server">
+            <summary>
+            Gets or sets the server.
+            </summary>
+            <value>
+            The server.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.Tag">
+            <summary>
+            Gets or sets the tag.
+            </summary>
+            <value>
+            The tag.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.Sleep">
+            <summary>
+            Gets or sets the sleep.
+            </summary>
+            <value>
+            The sleep.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.RunLoop">
+            <summary>
+            Gets or sets a value indicating whether [run loop].
+            </summary>
+            <value>
+              <c>true</c> if [run loop]; otherwise, <c>false</c>.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.Duration">
+            <summary>
+            Gets or sets the duration.
+            </summary>
+            <value>
+            The duration.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.MaxErrors">
+            <summary>
+            Gets or sets the maximum errors.
+            </summary>
+            <value>
+            The maximum errors.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.DelayStart">
+            <summary>
+            Gets or sets the delay start.
+            </summary>
+            <value>
+            The delay start.
+            </value>
+        </member>
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.DryRun">
+            <summary>
+            Gets or sets a value indicating whether [dry run].
+            </summary>
+            <value>
+              <c>true</c> if [dry run]; otherwise, <c>false</c>.
+            </value>
+        </member>
         <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.EntityType">
             <summary>
             Gets the type of the entity.
@@ -1028,6 +1153,44 @@
             <value>
             The type of the entity.
             </value>
+        </member>
+        <member name="M:LodeRunner.Core.Models.LoadTestConfigPayload.OnPropertyChanged(System.String)">
+            <summary>
+            Called when [property changed].
+            </summary>
+            <param name="fieldName">The field name.</param>
+        </member>
+        <member name="M:LodeRunner.Core.Models.LoadTestConfigPayload.SetField(System.Collections.Generic.List{System.String}@,System.Collections.Generic.List{System.String},System.String)">
+            <summary>
+            Sets the field.
+            </summary>
+            <param name="field">The field.</param>
+            <param name="value">The value.</param>
+            <param name="callerMemberName">Name of the caller member.</param>
+        </member>
+        <member name="M:LodeRunner.Core.Models.LoadTestConfigPayload.SetField(System.Int32@,System.Int32,System.String)">
+            <summary>
+            Sets the field.
+            </summary>
+            <param name="field">The field.</param>
+            <param name="value">The value.</param>
+            <param name="callerMemberName">Name of the caller member.</param>
+        </member>
+        <member name="M:LodeRunner.Core.Models.LoadTestConfigPayload.SetField(System.String@,System.String,System.String)">
+            <summary>
+            Sets the field.
+            </summary>
+            <param name="field">The field.</param>
+            <param name="value">The value.</param>
+            <param name="callerMemberName">Name of the caller member.</param>
+        </member>
+        <member name="M:LodeRunner.Core.Models.LoadTestConfigPayload.SetField(System.Boolean@,System.Boolean,System.String)">
+            <summary>
+            Sets the field.
+            </summary>
+            <param name="field">if set to <c>true</c> [field].</param>
+            <param name="value">if set to <c>true</c> [value].</param>
+            <param name="callerMemberName">Name of the caller member.</param>
         </member>
         <member name="T:LodeRunner.Core.Models.TestRun">
             <summary>

--- a/src/LodeRunner.Core/Models/LoadTestConfig.cs
+++ b/src/LodeRunner.Core/Models/LoadTestConfig.cs
@@ -26,7 +26,7 @@ namespace LodeRunner.Core.Models
         [Required]
         [ValidateList(ErrorMessage = "Files list cannot be null or empty.")]
         [Description("-f")]
-        public List<string> Files { get; set; }
+        public virtual List<string> Files { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether [strict json].
@@ -35,7 +35,7 @@ namespace LodeRunner.Core.Models
         ///   <c>true</c> if [strict json]; otherwise, <c>false</c>.
         /// </value>
         [Description("-j")]
-        public bool StrictJson { get; set; }
+        public virtual bool StrictJson { get; set; }
 
         /// <summary>
         /// Gets or sets the base URL.
@@ -44,7 +44,7 @@ namespace LodeRunner.Core.Models
         /// The base URL.
         /// </value>
         [Description("--base-url")]
-        public string BaseURL { get; set; }
+        public virtual string BaseURL { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether [verbose errors].
@@ -53,7 +53,7 @@ namespace LodeRunner.Core.Models
         ///   <c>true</c> if [verbose errors]; otherwise, <c>false</c>.
         /// </value>
         [Description("--verbose-errors")]
-        public bool VerboseErrors { get; set; }
+        public virtual bool VerboseErrors { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="LoadTestConfig"/> is randomize.
@@ -62,7 +62,7 @@ namespace LodeRunner.Core.Models
         ///   <c>true</c> if randomize; otherwise, <c>false</c>.
         /// </value>
         [Description("--random")]
-        public bool Randomize { get; set; }
+        public virtual bool Randomize { get; set; }
 
         /// <summary>
         /// Gets or sets the timeout.
@@ -71,7 +71,7 @@ namespace LodeRunner.Core.Models
         /// The timeout.
         /// </value>
         [Description("--timeout")]
-        public int Timeout { get; set; }
+        public virtual int Timeout { get; set; }
 
         /// <summary>
         /// Gets or sets the server.
@@ -82,7 +82,7 @@ namespace LodeRunner.Core.Models
         [Required]
         [ValidateList(ErrorMessage = "Server list cannot be null or empty.")]
         [Description("-s")]
-        public List<string> Server { get; set; }
+        public virtual List<string> Server { get; set; }
 
         /// <summary>
         /// Gets or sets the tag.
@@ -91,7 +91,7 @@ namespace LodeRunner.Core.Models
         /// The tag.
         /// </value>
         [Description("--tag")]
-        public string Tag { get; set; }
+        public virtual string Tag { get; set; }
 
         /// <summary>
         /// Gets or sets the sleep.
@@ -100,7 +100,7 @@ namespace LodeRunner.Core.Models
         /// The sleep.
         /// </value>
         [Description("--sleep")]
-        public int Sleep { get; set; }
+        public virtual int Sleep { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether [run loop].
@@ -109,7 +109,7 @@ namespace LodeRunner.Core.Models
         ///   <c>true</c> if [run loop]; otherwise, <c>false</c>.
         /// </value>
         [Description("--run-loop")]
-        public bool RunLoop { get; set; }
+        public virtual bool RunLoop { get; set; }
 
         /// <summary>
         /// Gets or sets the duration.
@@ -118,7 +118,7 @@ namespace LodeRunner.Core.Models
         /// The duration.
         /// </value>
         [Description("--duration")]
-        public int Duration { get; set; }
+        public virtual int Duration { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum errors.
@@ -127,7 +127,7 @@ namespace LodeRunner.Core.Models
         /// The maximum errors.
         /// </value>
         [Description("--max-errors")]
-        public int MaxErrors { get; set; }
+        public virtual int MaxErrors { get; set; }
 
         /// <summary>
         /// Gets or sets the delay start.
@@ -138,7 +138,7 @@ namespace LodeRunner.Core.Models
         [Required]
         [Range(0, 86400, ErrorMessage = "Can only be between 0 .. 86400")]
         [Description("--delay-start")]
-        public int DelayStart { get; set; }
+        public virtual int DelayStart { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether [dry run].
@@ -147,6 +147,6 @@ namespace LodeRunner.Core.Models
         ///   <c>true</c> if [dry run]; otherwise, <c>false</c>.
         /// </value>
         [Description("--dry-run")]
-        public bool DryRun { get; set; }
+        public virtual bool DryRun { get; set; }
     }
 }

--- a/src/LodeRunner.Core/Models/LoadTestConfigPayload.cs
+++ b/src/LodeRunner.Core/Models/LoadTestConfigPayload.cs
@@ -1,7 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
 using LodeRunner.Core.Extensions;
+using LodeRunner.Core.Models.Validators;
 using LodeRunner.Core.SchemaFilters;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -11,8 +16,148 @@ namespace LodeRunner.Core.Models
     /// LoadRestConfig Payload.
     /// </summary>
     [SwaggerSchemaFilter(typeof(LoadTestConfigPayloadSchemaFilter))]
-    public class LoadTestConfigPayload : LoadTestConfig
+    public class LoadTestConfigPayload : LoadTestConfig, INotifyPropertyChanged
     {
+        private List<string> files;
+        private bool strictJson;
+        private string baseURL;
+        private bool verboseErrors;
+        private bool randomize;
+        private int timeout;
+        private List<string> server;
+        private string tag;
+        private int sleep;
+        private bool runLoop;
+        private int duration;
+        private int maxErrors;
+        private int delayStart;
+        private bool dryRun;
+
+        /// <summary>
+        /// Occurs when a property value changes.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Gets or sets the properties changed list.
+        /// </summary>
+        /// <value>
+        /// The changed properties.
+        /// </value>
+        public List<string> PropertiesChanged { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the files.
+        /// </summary>
+        /// <value>
+        /// The files.
+        /// </value>
+        public override List<string> Files { get => this.files; set => this.SetField(ref this.files, value); }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [strict json].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [strict json]; otherwise, <c>false</c>.
+        /// </value>
+        public override bool StrictJson { get => this.strictJson; set => this.SetField(ref this.strictJson, value); }
+
+        /// <summary>
+        /// Gets or sets the base URL.
+        /// </summary>
+        /// <value>
+        /// The base URL.
+        /// </value>
+        public override string BaseURL { get => this.baseURL; set => this.SetField(ref this.baseURL, value); }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [verbose errors].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [verbose errors]; otherwise, <c>false</c>.
+        /// </value>
+        public override bool VerboseErrors { get => this.verboseErrors; set => this.SetField(ref this.verboseErrors, value); }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="LoadTestConfig"/> is randomize.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if randomize; otherwise, <c>false</c>.
+        /// </value>
+        public override bool Randomize { get => this.randomize; set => this.SetField(ref this.randomize, value); }
+
+        /// <summary>
+        /// Gets or sets the timeout.
+        /// </summary>
+        /// <value>
+        /// The timeout.
+        /// </value>
+        public override int Timeout { get => this.timeout; set => this.SetField(ref this.timeout, value); }
+
+        /// <summary>
+        /// Gets or sets the server.
+        /// </summary>
+        /// <value>
+        /// The server.
+        /// </value>
+        public override List<string> Server { get => this.server; set => this.SetField(ref this.server, value); }
+
+        /// <summary>
+        /// Gets or sets the tag.
+        /// </summary>
+        /// <value>
+        /// The tag.
+        /// </value>
+        public override string Tag { get => this.tag; set => this.SetField(ref this.tag, value); }
+
+        /// <summary>
+        /// Gets or sets the sleep.
+        /// </summary>
+        /// <value>
+        /// The sleep.
+        /// </value>
+        public override int Sleep { get => this.sleep; set => this.SetField(ref this.sleep, value); }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [run loop].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [run loop]; otherwise, <c>false</c>.
+        /// </value>
+        public override bool RunLoop { get => this.runLoop; set => this.SetField(ref this.runLoop, value); }
+
+        /// <summary>
+        /// Gets or sets the duration.
+        /// </summary>
+        /// <value>
+        /// The duration.
+        /// </value>
+        public override int Duration { get => this.duration; set => this.SetField(ref this.duration, value); }
+
+        /// <summary>
+        /// Gets or sets the maximum errors.
+        /// </summary>
+        /// <value>
+        /// The maximum errors.
+        /// </value>
+        public override int MaxErrors { get => this.maxErrors; set => this.SetField(ref this.maxErrors, value); }
+
+        /// <summary>
+        /// Gets or sets the delay start.
+        /// </summary>
+        /// <value>
+        /// The delay start.
+        /// </value>
+        public override int DelayStart { get => this.delayStart; set => this.SetField(ref this.delayStart, value); }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [dry run].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [dry run]; otherwise, <c>false</c>.
+        /// </value>
+        public override bool DryRun { get => this.dryRun; set => this.SetField(ref this.dryRun, value); }
+
         /// <summary>
         /// Gets the type of the entity.
         /// </summary>
@@ -30,6 +175,67 @@ namespace LodeRunner.Core.Models
 
                 return this.entityType;
             }
+        }
+
+        /// <summary>
+        /// Called when [property changed].
+        /// </summary>
+        /// <param name="fieldName">The field name.</param>
+        protected void OnPropertyChanged([CallerMemberName] string fieldName = null)
+        {
+            if (!this.PropertiesChanged.Contains(fieldName))
+            {
+                this.PropertiesChanged.Add(fieldName);
+                this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(fieldName));
+            }
+        }
+
+        /// <summary>
+        /// Sets the field.
+        /// </summary>
+        /// <param name="field">The field.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="callerMemberName">Name of the caller member.</param>
+        private void SetField(ref List<string> field, List<string> value, [CallerMemberName] string callerMemberName = null)
+        {
+            field = value;
+            this.OnPropertyChanged(callerMemberName);
+        }
+
+        /// <summary>
+        /// Sets the field.
+        /// </summary>
+        /// <param name="field">The field.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="callerMemberName">Name of the caller member.</param>
+        private void SetField(ref int field, int value, [CallerMemberName] string callerMemberName = null)
+        {
+            field = value;
+            this.OnPropertyChanged(callerMemberName);
+        }
+
+        /// <summary>
+        /// Sets the field.
+        /// </summary>
+        /// <param name="field">The field.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="callerMemberName">Name of the caller member.</param>
+        private void SetField(ref string field, string value, [CallerMemberName] string callerMemberName = null)
+        {
+            field = value;
+            this.OnPropertyChanged(callerMemberName);
+        }
+
+        /// <summary>
+        /// Sets the field.
+        /// </summary>
+        /// <param name="field">if set to <c>true</c> [field].</param>
+        /// <param name="value">if set to <c>true</c> [value].</param>
+        /// <param name="callerMemberName">Name of the caller member.</param>
+        private void SetField(ref bool field, bool value, [CallerMemberName] string callerMemberName = null)
+        {
+            field = value;
+            this.OnPropertyChanged(callerMemberName);
         }
     }
 }

--- a/src/LodeRunner.Test/UnitTests/CommandLineArgs.cs
+++ b/src/LodeRunner.Test/UnitTests/CommandLineArgs.cs
@@ -108,6 +108,7 @@ namespace LodeRunner.Test.UnitTests
         [InlineData(new string[] { "--mode", Core.SystemConstants.LodeRunnerCommandMode, "-s", "https://somerandomdomain.com", "-f", "memory-baseline.json", "--random", "true" }, Core.SystemConstants.CmdLineValidationRandomAndLoopMessage, "Validation for --random")]
         [InlineData(new string[] { "--mode", Core.SystemConstants.LodeRunnerCommandMode, "-s", "https://somerandomdomain.com", "-f", "memory-baseline.json", "--delay-start", "-1" }, "must be an integer >= 0", "Argument --delay-start")]
         [InlineData(new string[] { "--mode", Core.SystemConstants.LodeRunnerCommandMode, "-s", "https://somerandomdomain.com", "-f", "memory-baseline.json", "--secrets-volume", "go" }, "must be at least 3 characters", "Argument --secrets-volume")]
+        [InlineData(new string[] { "--mode", Core.SystemConstants.LodeRunnerCommandMode, "-s", "https://somerandomdomain.com", "-f", "memory-baseline.json", "--duration", "-2" }, "must be an integer >= 1", "Argument --duration")]
         public void CommandMode_ValidateDependencies_Failure(string[] args, string expectedErrorMessage, string messageifFailed)
         {
             RootCommand root = LRCommandLine.BuildRootCommandMode();
@@ -115,37 +116,6 @@ namespace LodeRunner.Test.UnitTests
             var errors = root.Parse(args).Errors;
 
             Assert.True(errors.Count == 1 && errors.Any(m => m.Message.Contains(expectedErrorMessage)), messageifFailed);
-        }
-
-        /// <summary>
-        /// Test the failure case of LodeRunner in Traditional mode when validating dependencies for the ones that use GetValueOrDefault.
-        /// </summary>
-        /// <param name="args">The arguments.</param>
-        /// <param name="expectedErrorMessage">The expected error message.</param>
-        /// <param name="messageifFailed">The message to display if test failed.</param>
-        [Theory]
-        [Trait("Category", "Unit")]
-        [InlineData(new string[] { "--mode", Core.SystemConstants.LodeRunnerCommandMode, "-s", "https://somerandomdomain.com", "-f", "memory-baseline.json", "--duration", "-2" }, "must be an integer >= 1", "Argument --duration")]
-        public void CommandMode_ValidateDependencies_With_Invalid_Data_And_GetValueOrDefault(string[] args, string expectedErrorMessage, string messageifFailed)
-        {
-            // Note: we do not need to test for "--run-loop" and "--random" since they are both boolean type and default to "true", so exception is never thrown.
-            RootCommand root = LRCommandLine.BuildRootCommandMode();
-
-            try
-            {
-                var errors = root.Parse(args).Errors;
-                Assert.True(false, "Previous line should have thrown a General Exception based on InLineData. InlineData is not appropriate for this Unit Test.");
-
-                // Note: if Assert failed, try to move InLineData to UnitTest CommandMode_ValidateDependencies_Failure()
-            }
-            catch (Xunit.Sdk.TrueException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Assert.True(ex.Message.Contains(expectedErrorMessage), messageifFailed);
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
<!-- Concise description of the problem and the solution or the feature being added -->

- Fix bug LodeRunner.API 500 when only required values are POSTed

- Also fixed a found undercover bug related to incorrect conversion from Payload properties to arguments. 

For instance, if we want to create a new load test config with the only 2 arguments e.g. Server and Files, at the time we convert the payload to arguments list, the previous logic was looping thru all payload DTO properties and as a result arguments array included all possible ones with default values which was not the intent at the time, we submitted the create request , that ended up on several command line argument parsing validations to fail.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [x] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes #501
