### PR TITLE
Update LodeRunner.UI to display a message when no clients are available

### DIFF
--- a/src/LodeRunner.UI/src/components/Clients/index.js
+++ b/src/LodeRunner.UI/src/components/Clients/index.js
@@ -44,40 +44,46 @@ const Clients = ({ setFetchClientsInterval }) => {
         <option value="60000">1 minute</option>
       </select>
       <div>
-        {clients.map((c, index) => {
-          const {
-            [CLIENT.loadClientId]: loadClientId,
-            [CLIENT.status]: status,
-            [CLIENT.name]: name,
-          } = c;
-          return (
-            <div key={loadClientId} className="clients-item">
-              <button
-                className="clients-item-select"
-                type="button"
-                onClick={() => toggleClient(loadClientId)}
-                onKeyDown={() => toggleClient(loadClientId)}
-              >
-                {name || "Unknown"}
-                {selectedClients[loadClientId] && (
-                  <CheckMark fillColor="white" width="1em" />
-                )}
-              </button>
-              <button
-                className={`clients-item-status ${
-                  status === CLIENT_STATUSES.ready ? "ready" : "pending"
-                } ${openedClientDetailsIndex === index && "selected"}`}
-                type="button"
-                title={status}
-                aria-label={status}
-                onClick={() => toggleClientDetails(index)}
-                onKeyDown={() => toggleClientDetails(index)}
-              >
-                {openedClientDetailsIndex === index && ">"}
-              </button>
-            </div>
-          );
-        })}
+        {clients && clients.length > 0 ? (
+          clients.map((c, index) => {
+            const {
+              [CLIENT.loadClientId]: loadClientId,
+              [CLIENT.status]: status,
+              [CLIENT.name]: name,
+            } = c;
+            return (
+              <div key={loadClientId} className="clients-item">
+                <button
+                  className="clients-item-select"
+                  type="button"
+                  onClick={() => toggleClient(loadClientId)}
+                  onKeyDown={() => toggleClient(loadClientId)}
+                >
+                  {name || "Unknown"}
+                  {selectedClients[loadClientId] && (
+                    <CheckMark fillColor="white" width="1em" />
+                  )}
+                </button>
+                <button
+                  className={`clients-item-status ${
+                    status === CLIENT_STATUSES.ready ? "ready" : "pending"
+                  } ${openedClientDetailsIndex === index && "selected"}`}
+                  type="button"
+                  title={status}
+                  aria-label={status}
+                  onClick={() => toggleClientDetails(index)}
+                  onKeyDown={() => toggleClientDetails(index)}
+                >
+                  {openedClientDetailsIndex === index && ">"}
+                </button>
+              </div>
+            );
+          })
+        ) : (
+          <div className="clients-notification">
+            <p>No Load Clients Available</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/LodeRunner.UI/src/components/Clients/styles.css
+++ b/src/LodeRunner.UI/src/components/Clients/styles.css
@@ -13,6 +13,9 @@
   margin: 0;
   margin-bottom: 1em;
 }
+.clients-notification {
+  font-weight: bold;
+}
 .clients-item {
   display: flex;
   margin: 6px 0;


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR

Update the Clients component in the UI to render the message, No Load Clients Available, when the UI does not have clients to render. The UI renders the same as before if clients are available.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Validation

- [x] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/508