### PR TITLE
Disable duration check when run-loop is empty/false

### DIFF
--- a/src/LodeRunner.API/LodeRunnerApi.xml
+++ b/src/LodeRunner.API/LodeRunnerApi.xml
@@ -4,15 +4,15 @@
         <name>LodeRunner.API</name>
     </assembly>
     <members>
-        <member name="T:LodeRunner.API.AutoMapperProfiles.LoadTestConfigProfile">
+        <member name="T:LodeRunner.API.AutoMapperProfiles.LoadTestPayloadProfile">
             <summary>
             Represents the LoadTestConfig Auto-mapping Profile.
             </summary>
             <seealso cref="T:AutoMapper.Profile" />
         </member>
-        <member name="M:LodeRunner.API.AutoMapperProfiles.LoadTestConfigProfile.#ctor">
+        <member name="M:LodeRunner.API.AutoMapperProfiles.LoadTestPayloadProfile.#ctor">
             <summary>
-            Initializes a new instance of the <see cref="T:LodeRunner.API.AutoMapperProfiles.LoadTestConfigProfile"/> class.
+            Initializes a new instance of the <see cref="T:LodeRunner.API.AutoMapperProfiles.LoadTestPayloadProfile"/> class.
             </summary>
         </member>
         <member name="T:LodeRunner.API.Controllers.ClientsController">
@@ -117,6 +117,28 @@
             </summary>
             <param name="loadTestConfigId">The Load Test Config id to delete</param>
             <param name="loadTestConfigService">The load Test Config Service.</param>
+            <param name="cancellationTokenSource">The cancellation token source.</param>
+            <returns>IActionResult.</returns>
+        </member>
+        <member name="M:LodeRunner.API.Controllers.LoadTestConfigsController.UpdateLoadTestConfig(System.String,LodeRunner.Core.Models.LoadTestConfigPayload,LodeRunner.Data.Interfaces.ILoadTestConfigService,System.Threading.CancellationTokenSource)">
+            <summary>
+            Updates a load test configuration.
+            The payload doesn't have to be a full LoadTestConfig item.
+            Partial payload with only changed fields are accepted too.
+            </summary>
+            <example>
+            Payload Example 1: {"duration":222}
+                    Example 2: {
+                                 "baseURL": "lode-url.org",
+                                 "runLoop": true,
+                                 "duration": 333,
+                                 "timeout": 303,
+                                 "files":[ "/path/to/gem.json" ]
+                               }
+            </example>
+            <param name="loadTestConfigId">The load test config id.</param>
+            <param name="loadTestConfigPayload">The load test config payload.</param>
+            <param name="loadTestConfigService">Load test config Service.</param>
             <param name="cancellationTokenSource">The cancellation token source.</param>
             <returns>IActionResult.</returns>
         </member>
@@ -356,13 +378,13 @@
             Provides Extension methods for Models.
             </summary>
         </member>
-        <member name="M:LodeRunner.API.Middleware.ModelExtensions.Validate(LodeRunner.Core.Models.LoadTestConfig,System.Collections.Generic.List{System.String},System.String@)">
+        <member name="M:LodeRunner.API.Middleware.ModelExtensions.Validate(LodeRunner.Core.Models.LoadTestConfig,System.String@,System.Collections.Generic.List{System.String})">
             <summary>
             Validates the specified load test payload configuration.
             </summary>
             <param name="loadTestConfig">The load test configuration.</param>
-            <param name="payloadPropertiesChanged">Payload Properties Change list.</param>
             <param name="errorMessage">Error MEssage String if any.</param>
+            <param name="payloadPropertiesChanged">Payload Properties Change list.</param>
             <returns>Whether or not  the DTO passes validation.</returns>
         </member>
         <member name="M:LodeRunner.API.Middleware.ModelExtensions.GetArgs(LodeRunner.Core.Models.LoadTestConfig,System.Collections.Generic.List{System.String})">
@@ -483,6 +505,13 @@
             <summary>
             Handles query requests from the controllers.
             </summary>
+        </member>
+        <member name="M:LodeRunner.API.Middleware.ResultHandler.CreateNoContent(System.Net.HttpStatusCode)">
+            <summary>
+            Creates No Content Result.
+            </summary>
+            <param name="statusCode">Http StatusCode.</param>
+            <returns>JsonResult.</returns>
         </member>
         <member name="M:LodeRunner.API.Middleware.ResultHandler.CreateErrorResult(System.String,System.Net.HttpStatusCode)">
             <summary>
@@ -969,6 +998,21 @@
         <member name="F:LodeRunner.API.SystemConstants.NotFoundLoadTestConfig">
             <summary>
             The load test configuration was not found.
+            </summary>
+        </member>
+        <member name="F:LodeRunner.API.SystemConstants.UnableToUpdateLoadTestConfig">
+            <summary>
+            String for unable to update load test configuration.
+            </summary>
+        </member>
+        <member name="F:LodeRunner.API.SystemConstants.UnableToGetLoadTestConfig">
+            <summary>
+            String for unable to update load test configuration.
+            </summary>
+        </member>
+        <member name="F:LodeRunner.API.SystemConstants.InvalidPayloadData">
+            <summary>
+            Invalid Payload data.
             </summary>
         </member>
         <member name="T:LodeRunner.API.Data.LRAPICache">

--- a/src/LodeRunner.Core/CommandLine/LRCommandLine.cs
+++ b/src/LodeRunner.Core/CommandLine/LRCommandLine.cs
@@ -65,7 +65,7 @@ namespace LodeRunner.Core.CommandLine
             root.AddOption(new Option<bool>(new string[] { "-r", "--run-loop" }, Parsers.ParseBool, true, "Run test in an infinite loop"));
             root.AddOption(new Option<bool>(new string[] { "--verbose-errors" }, Parsers.ParseBool, true, "Log verbose error messages"));
             root.AddOption(new Option<bool>(new string[] { "--random" }, Parsers.ParseBool, true, "Run requests randomly (requires --run-loop)"));
-            root.AddOption(new Option<int>(new string[] { "--duration" }, Parsers.ParseIntGTZero, true, "Test duration (seconds)  (requires --run-loop)"));
+            root.AddOption(new Option<int>(new string[] { "--duration" }, Parsers.ParseIntGEZero, true, "Test duration (seconds)  (requires --run-loop)"));
             root.AddOption(new Option<int>(new string[] { "--summary-minutes" }, Parsers.ParseIntGTZero, true, "Display summary results (minutes)  (requires --run-loop)"));
             root.AddOption(new Option<int>(new string[] { "-t", "--timeout" }, Parsers.ParseIntGTZero, true, "Request timeout (seconds)"));
             root.AddOption(new Option<int>(new string[] { "--max-concurrent" }, Parsers.ParseIntGTZero, true, "Max concurrent requests"));
@@ -229,9 +229,9 @@ namespace LodeRunner.Core.CommandLine
                 // What happens is that when a integer type parameter such as duration is not provided and we try to get the value utilizing method GetValueOrDefault. it throws an exception.
             }
 
-            if (duration != null && duration > 0 && !runLoop)
+            if (duration != null && duration == 0 && runLoop)
             {
-                msg += $"{SystemConstants.CmdLineValidationDurationAndLoopMessage}\n";
+                Console.WriteLine(SystemConstants.CmdLineNoticeDurationValueIgnoredMessage);
             }
             else if (random && !runLoop)
             {

--- a/src/LodeRunner.Core/CommandLine/Parsers.cs
+++ b/src/LodeRunner.Core/CommandLine/Parsers.cs
@@ -263,13 +263,13 @@ namespace LodeRunner.Core.CommandLine
                 return -1;
             }
 
-            // use default sleep value if 0 passed and run-loop set
+            // if run-loop is set, check for sleep dependency
             if (result.Parent.Symbol.Name == "sleep" &&
                 val == 0 &&
                 result.Parent.Parent.Children.FirstOrDefault(c => c.Symbol.Name == "run-loop") is OptionResult res &&
                 res.GetValueOrDefault<bool>())
             {
-                Console.WriteLine("--sleep value of 0 is incompatible while --run-loop is also set. --sleep value will be ignored and reset to the default.");
+                Console.WriteLine(SystemConstants.CmdLineNoticeSleepValueIgnoredMessage);
                 return GetCommandDefaultValues(result);
             }
 
@@ -297,6 +297,9 @@ namespace LodeRunner.Core.CommandLine
                     }
 
                     return 0;
+                case "duration":
+                    // default is -1 to differentiate when duration of 0 is passed
+                    return -1;
                 case "timeout":
                     return 30;
                 default:

--- a/src/LodeRunner.Core/LodeRunner.Core.xml
+++ b/src/LodeRunner.Core/LodeRunner.Core.xml
@@ -1151,12 +1151,12 @@
               <c>true</c> if [dry run]; otherwise, <c>false</c>.
             </value>
         </member>
-        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.EntityType">
+        <member name="P:LodeRunner.Core.Models.LoadTestConfigPayload.Name">
             <summary>
-            Gets the type of the entity.
+            Gets or sets the name.
             </summary>
             <value>
-            The type of the entity.
+            The name.
             </value>
         </member>
         <member name="M:LodeRunner.Core.Models.LoadTestConfigPayload.OnPropertyChanged(System.String)">
@@ -1165,37 +1165,15 @@
             </summary>
             <param name="fieldName">The field name.</param>
         </member>
-        <member name="M:LodeRunner.Core.Models.LoadTestConfigPayload.SetField(System.Collections.Generic.List{System.String}@,System.Collections.Generic.List{System.String},System.String)">
+        <member name="M:LodeRunner.Core.Models.LoadTestConfigPayload.SetField``1(``0,System.String)">
             <summary>
-            Sets the field.
+            Sets the field on LoadTestConfig based on the field.
+            Assuming property names in this class are the same as in LoadTestConfig.
+            We're using the Reflected [CallerMemberName] property, assuming we're calling this from the same property we want to change in LoadTestConfig
+            If this is called from a method, propertyName should be set explicitly.
             </summary>
-            <param name="field">The field.</param>
             <param name="value">The value.</param>
-            <param name="callerMemberName">Name of the caller member.</param>
-        </member>
-        <member name="M:LodeRunner.Core.Models.LoadTestConfigPayload.SetField(System.Int32@,System.Int32,System.String)">
-            <summary>
-            Sets the field.
-            </summary>
-            <param name="field">The field.</param>
-            <param name="value">The value.</param>
-            <param name="callerMemberName">Name of the caller member.</param>
-        </member>
-        <member name="M:LodeRunner.Core.Models.LoadTestConfigPayload.SetField(System.String@,System.String,System.String)">
-            <summary>
-            Sets the field.
-            </summary>
-            <param name="field">The field.</param>
-            <param name="value">The value.</param>
-            <param name="callerMemberName">Name of the caller member.</param>
-        </member>
-        <member name="M:LodeRunner.Core.Models.LoadTestConfigPayload.SetField(System.Boolean@,System.Boolean,System.String)">
-            <summary>
-            Sets the field.
-            </summary>
-            <param name="field">if set to <c>true</c> [field].</param>
-            <param name="value">if set to <c>true</c> [value].</param>
-            <param name="callerMemberName">Name of the caller member.</param>
+            <param name="propertyName">Name of the caller propert.</param>
         </member>
         <member name="T:LodeRunner.Core.Models.TestRun">
             <summary>
@@ -1416,11 +1394,6 @@
             The AppSetting development environment name.
             </summary>
         </member>
-        <member name="F:LodeRunner.Core.SystemConstants.CmdLineValidationDurationAndLoopMessage">
-            <summary>
-            The command line validation duration and loop message.
-            </summary>
-        </member>
         <member name="F:LodeRunner.Core.SystemConstants.CmdLineValidationRandomAndLoopMessage">
             <summary>
             The command line validation random and loop message.
@@ -1439,6 +1412,16 @@
         <member name="F:LodeRunner.Core.SystemConstants.CmdLineValidationSecretsVolumeEndMessage">
             <summary>
             The command line validation secrets volume end message.
+            </summary>
+        </member>
+        <member name="F:LodeRunner.Core.SystemConstants.CmdLineNoticeSleepValueIgnoredMessage">
+            <summary>
+            The command line notice message that sleep value is ignored.
+            </summary>
+        </member>
+        <member name="F:LodeRunner.Core.SystemConstants.CmdLineNoticeDurationValueIgnoredMessage">
+            <summary>
+            The command line notice message that duration value is ignored.
             </summary>
         </member>
         <member name="F:LodeRunner.Core.SystemConstants.ExitSuccess">

--- a/src/LodeRunner.Core/SystemConstants.cs
+++ b/src/LodeRunner.Core/SystemConstants.cs
@@ -55,11 +55,6 @@ namespace LodeRunner.Core
         public const string DevelopmentEnvironment = "Development";
 
         /// <summary>
-        /// The command line validation duration and loop message.
-        /// </summary>
-        public const string CmdLineValidationDurationAndLoopMessage = "--run-loop must be true to use --duration";
-
-        /// <summary>
         /// The command line validation random and loop message.
         /// </summary>
         public const string CmdLineValidationRandomAndLoopMessage = "--run-loop must be true to use --random";
@@ -78,6 +73,16 @@ namespace LodeRunner.Core
         /// The command line validation secrets volume end message.
         /// </summary>
         public const string CmdLineValidationSecretsVolumeEndMessage = ") does not exist";
+
+        /// <summary>
+        /// The command line notice message that sleep value is ignored.
+        /// </summary>
+        public const string CmdLineNoticeSleepValueIgnoredMessage = "--sleep value of 0 is ignored while --run-loop is also set";
+
+        /// <summary>
+        /// The command line notice message that duration value is ignored.
+        /// </summary>
+        public const string CmdLineNoticeDurationValueIgnoredMessage = "--duration value of 0 is ignored while --run-loop is also set";
 
         /// <summary>
         /// The exit success.


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
When run-loop is not passed/set to false, allow passing of duration value. previously setting duration would error out
add log message that ignores duration value of 0 when runloop is set

## Does this introduce a breaking change

- [ ] YES
- [x] NO


## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/499