### PR TITLE
Only Display Max Errors When Run Loop Is Disabled

### DIFF
--- a/src/LodeRunner.UI/src/components/ConfigForm/IntegerInput/index.js
+++ b/src/LodeRunner.UI/src/components/ConfigForm/IntegerInput/index.js
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import { useEffect } from "react";
 
 const IntegerInput = ({
   label,
@@ -8,32 +7,25 @@ const IntegerInput = ({
   inputName,
   units,
   defaultValue,
-}) => {
-  console.log({ inputName, defaultValue });
-  useEffect(() => {
-    // eslint-disable-next-line no-param-reassign
-    elRef.current.value = defaultValue;
-  }, []);
-  return (
-    <div className="configform-input">
-      <label htmlFor={inputName}>
-        <span className="configform-input-label">{label}: </span>
-        {description}
-        <br />
-        <input
-          key={inputName}
-          ref={elRef}
-          type="number"
-          step="1"
-          name={inputName}
-          defaultValue={defaultValue}
-        />
-        &nbsp;
-        {units}
-      </label>
-    </div>
-  );
-};
+}) => (
+  <div className="configform-input">
+    <label htmlFor={inputName}>
+      <span className="configform-input-label">{label}: </span>
+      {description}
+      <br />
+      <input
+        key={inputName}
+        ref={elRef}
+        type="number"
+        step="1"
+        name={inputName}
+        defaultValue={defaultValue}
+      />
+      &nbsp;
+      {units}
+    </label>
+  </div>
+);
 
 IntegerInput.propTypes = {
   label: PropTypes.string.isRequired,

--- a/src/LodeRunner.UI/src/components/ConfigForm/IntegerInput/index.js
+++ b/src/LodeRunner.UI/src/components/ConfigForm/IntegerInput/index.js
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+import { useEffect } from "react";
 
 const IntegerInput = ({
   label,
@@ -7,24 +8,31 @@ const IntegerInput = ({
   inputName,
   units,
   defaultValue,
-}) => (
-  <div className="configform-input">
-    <label htmlFor={inputName}>
-      <span className="configform-input-label">{label}: </span>
-      {description}
-      <br />
-      <input
-        ref={elRef}
-        type="number"
-        step="1"
-        name={inputName}
-        defaultValue={defaultValue}
-      />
-      &nbsp;
-      {units}
-    </label>
-  </div>
-);
+}) => {
+  useEffect(() => {
+    console.log("use effect", { elRef, defaultValue });
+    // eslint-disable-next-line no-param-reassign
+    elRef.current.value = defaultValue;
+  }, []);
+  return (
+    <div className="configform-input">
+      <label htmlFor={inputName}>
+        <span className="configform-input-label">{label}: </span>
+        {description}
+        <br />
+        <input
+          ref={elRef}
+          type="number"
+          step="1"
+          name={inputName}
+          defaultValue={defaultValue}
+        />
+        &nbsp;
+        {units}
+      </label>
+    </div>
+  );
+};
 
 IntegerInput.propTypes = {
   label: PropTypes.string.isRequired,

--- a/src/LodeRunner.UI/src/components/ConfigForm/IntegerInput/index.js
+++ b/src/LodeRunner.UI/src/components/ConfigForm/IntegerInput/index.js
@@ -9,8 +9,8 @@ const IntegerInput = ({
   units,
   defaultValue,
 }) => {
+  console.log({ inputName, defaultValue });
   useEffect(() => {
-    console.log("use effect", { elRef, defaultValue });
     // eslint-disable-next-line no-param-reassign
     elRef.current.value = defaultValue;
   }, []);
@@ -21,6 +21,7 @@ const IntegerInput = ({
         {description}
         <br />
         <input
+          key={inputName}
           ref={elRef}
           type="number"
           step="1"

--- a/src/LodeRunner.UI/src/components/ConfigForm/index.js
+++ b/src/LodeRunner.UI/src/components/ConfigForm/index.js
@@ -87,9 +87,12 @@ const ConfigForm = () => {
     baseUrlFlagRef.current.value = openedConfig[CONFIG.baseUrl] || "";
     configNameRef.current.value = openedConfig[CONFIG.name] || "";
     if (durationFlagRef.current) {
+      console.log("line 90", { durationFlagRef });
       durationFlagRef.current.value = openedConfig[CONFIG.duration];
     }
-    maxErrorsFlagRef.current.value = openedConfig[CONFIG.maxErrors];
+    if (maxErrorsFlagRef.current) {
+      maxErrorsFlagRef.current.value = openedConfig[CONFIG.maxErrors];
+    }
     sleepFlagRef.current.value = openedConfig[CONFIG.sleep];
     tagFlagRef.current.value = openedConfig[CONFIG.tag] || "";
     timeoutFlagRef.current.value = openedConfig[CONFIG.timeout];
@@ -152,6 +155,7 @@ const ConfigForm = () => {
   const saveConfig = () => {
     setIsPending(true);
 
+    console.log("line 156", { durationFlagRef });
     const inputs = {
       [CONFIG.baseUrl]: baseUrlFlagRef.current.value,
       [CONFIG.dryRun]: dryRunFlagRef.current,
@@ -269,6 +273,7 @@ const ConfigForm = () => {
                 elRef={durationFlagRef}
                 inputName="durationFlag"
                 units="second(s)"
+                defaultValue={0}
               />
               {errors[CONFIG.duration] && (
                 <div className="configform-error">
@@ -294,6 +299,7 @@ const ConfigForm = () => {
                 description="Maximum validation errors"
                 elRef={maxErrorsFlagRef}
                 inputName="maxErrorsFlag"
+                defaultValue={10}
               />
               {errors[CONFIG.maxErrors] && (
                 <div className="configform-error">

--- a/src/LodeRunner.UI/src/components/ConfigForm/index.js
+++ b/src/LodeRunner.UI/src/components/ConfigForm/index.js
@@ -72,12 +72,6 @@ const ConfigForm = () => {
   const tagFlagRef = useRef();
   const timeoutFlagRef = useRef();
 
-  console.log("config form", {
-    maxErrorsFlagRef,
-    durationFlagRef,
-    randomizeFlagRef,
-  });
-
   useEffect(() => {
     // do not set initial values if new config
     if (!openedConfig) {
@@ -87,7 +81,6 @@ const ConfigForm = () => {
     baseUrlFlagRef.current.value = openedConfig[CONFIG.baseUrl] || "";
     configNameRef.current.value = openedConfig[CONFIG.name] || "";
     if (durationFlagRef.current) {
-      console.log("line 90", { durationFlagRef });
       durationFlagRef.current.value = openedConfig[CONFIG.duration];
     }
     if (maxErrorsFlagRef.current) {
@@ -155,7 +148,6 @@ const ConfigForm = () => {
   const saveConfig = () => {
     setIsPending(true);
 
-    console.log("line 156", { durationFlagRef });
     const inputs = {
       [CONFIG.baseUrl]: baseUrlFlagRef.current.value,
       [CONFIG.dryRun]: dryRunFlagRef.current,

--- a/src/LodeRunner.UI/src/components/ConfigForm/index.js
+++ b/src/LodeRunner.UI/src/components/ConfigForm/index.js
@@ -72,6 +72,12 @@ const ConfigForm = () => {
   const tagFlagRef = useRef();
   const timeoutFlagRef = useRef();
 
+  console.log("config form", {
+    maxErrorsFlagRef,
+    durationFlagRef,
+    randomizeFlagRef,
+  });
+
   useEffect(() => {
     // do not set initial values if new config
     if (!openedConfig) {
@@ -108,8 +114,7 @@ const ConfigForm = () => {
 
   const onRunLoopFlagRefChange = ({ target }) => {
     runLoopFlagRef.current = target.value === "true";
-    if (target.value !== "true") {
-      durationFlagRef.current.value = 0;
+    if (target.value === "false") {
       randomizeFlagRef.current = false;
     }
     setRunLoopFlagState(target.value === "true");
@@ -254,7 +259,7 @@ const ConfigForm = () => {
           inputName="runLoopFlag"
           onChange={onRunLoopFlagRefChange}
         />
-        {runLoopFlagState && (
+        {runLoopFlagState ? (
           <>
             <br />
             <div className="configform-runloop-dependent">
@@ -278,6 +283,23 @@ const ConfigForm = () => {
                 inputName="randomizeFlag"
                 onChange={onRefCurrentChange(randomizeFlagRef)}
               />
+            </div>
+          </>
+        ) : (
+          <>
+            <br />
+            <div className="configform-runloop-dependent">
+              <IntegerInput
+                label="Max Errors"
+                description="Maximum validation errors"
+                elRef={maxErrorsFlagRef}
+                inputName="maxErrorsFlag"
+              />
+              {errors[CONFIG.maxErrors] && (
+                <div className="configform-error">
+                  ERROR: {errors[CONFIG.maxErrors]}
+                </div>
+              )}
             </div>
           </>
         )}
@@ -314,18 +336,6 @@ const ConfigForm = () => {
         onChange={onRefCurrentChange(verboseErrorsFlagRef)}
       />
       <br />
-      <IntegerInput
-        label="Max Errors"
-        description="Maximum validation errors"
-        elRef={maxErrorsFlagRef}
-        inputName="maxErrorsFlag"
-        defaultValue={10}
-      />
-      {errors[CONFIG.maxErrors] && (
-        <div className="configform-error">
-          ERROR: {errors[CONFIG.maxErrors]}
-        </div>
-      )}
       <div className="configform-save">
         {!errors.response && Object.keys(errors).length > 0 && (
           <div className="configform-save-error configform-error">


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
Max Errors Will Only Appear on Form if Run Loop is Disabled

![image](https://user-images.githubusercontent.com/52010147/151260794-8ecd7060-d735-4892-bcc4-782e4999f726.png)
![image](https://user-images.githubusercontent.com/52010147/151260840-0b3a57d8-a0e5-45c3-afd1-f139667a5b4d.png)


## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/562
