### PR TITLE
Fixed bug: Loderunner in command mode fails when multiple servers are specified

### DIFF
--- a/src/LodeRunner.API.Test/IntegrationTests/Controllers/Clients.cs
+++ b/src/LodeRunner.API.Test/IntegrationTests/Controllers/Clients.cs
@@ -122,7 +122,8 @@ namespace LodeRunner.API.Test.IntegrationTests.Controllers
             Assert.NotEmpty(clients);
 
             // Assert for all required fields
-            clients.ForEach((c) => {
+            clients.ForEach((c) =>
+            {
                 Assert.NotNull(c.Version);
                 Assert.NotNull(c.Region);
                 Assert.NotNull(c.StartupArgs);

--- a/src/LodeRunner/src/Subscribers/ClientStatusUpdater.cs
+++ b/src/LodeRunner/src/Subscribers/ClientStatusUpdater.cs
@@ -50,6 +50,7 @@ namespace LodeRunner.Subscribers
             try
             {
                 _ = await this.clientStatusService.Post(this.clientStatus, args.CancelTokenSource.Token).ConfigureAwait(false);
+
                 // reset failure count on success
                 failures = 0;
             }

--- a/src/LodeRunner/src/ValidationTest/Main.cs
+++ b/src/LodeRunner/src/ValidationTest/Main.cs
@@ -610,7 +610,7 @@ namespace LodeRunner
         /// <returns>HttpClient.</returns>
         private HttpClient OpenHttpClient(string host)
         {
-            HttpClient client = new (httpSocketHandler)
+            HttpClient client = new (httpSocketHandler, disposeHandler: false)
             {
                 Timeout = new TimeSpan(0, 0, this.config.Timeout),
                 BaseAddress = new Uri(host),


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
<!-- Concise description of the problem and the solution or the feature being added -->
Loderunner in command mode fails when multiple servers are specified
## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [x] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/608
