### PR TITLE
Revert "Populate version in LR UI for github action main push (#178)"

### DIFF
--- a/.github/workflows/loderunner-ui.yaml
+++ b/.github/workflows/loderunner-ui.yaml
@@ -81,8 +81,6 @@ jobs:
       run: | 
         echo Docker Tag and Push because tag_and_push is- ${{ inputs.tag_and_push }}
 
-        VERSION=$(npm run version --silent)
-
         # tag the repo with :beta
         docker tag imageui $DOCKER_REPO:beta
 

--- a/src/LodeRunner.UI/package.json
+++ b/src/LodeRunner.UI/package.json
@@ -27,9 +27,7 @@
     "eject": "react-scripts eject",
     "lint": "eslint --fix 'src/**/*.{js,jsx}'",
     "lint-audit": "eslint 'src/**/*.{js,jsx}'",
-    "format": "prettier -w .",
-    "version": "echo $npm_package_version"
-
+    "format": "prettier -w ."
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This reverts commit 1a42f81a5d9ea5a5742b9d9aeb53402a5525e980.

# Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [x] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
<!-- Concise description of the problem and the solution or the feature being added -->
Get github workflow/action working for main push: building loderunner ui image

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes #issue_number (this will automatically close the issue when the PR closes)
- References https://github.com/retaildevcrews/wcnp/issues/663
