### PR TITLE
Fix UI issue where modal can be closed by clicking in the modal and releasing outside the modal

### DIFF
--- a/src/LodeRunner.UI/src/components/Modal/index.js
+++ b/src/LodeRunner.UI/src/components/Modal/index.js
@@ -6,7 +6,8 @@ const Modal = ({ children, content, setContent }) => {
   const closeModal = () => setContent(MODAL_CONTENT.closed);
 
   return (
-    <div role="presentation" className="modal-wrapper" onClick={closeModal}>
+    <>
+      <div role="presentation" className="modal-wrapper" onClick={closeModal}></div>
       <div
         role="presentation"
         className={`modal modal-${content.toLowerCase()}`}
@@ -25,7 +26,7 @@ const Modal = ({ children, content, setContent }) => {
         </div>
         {children}
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/LodeRunner.UI/src/components/Modal/styles.css
+++ b/src/LodeRunner.UI/src/components/Modal/styles.css
@@ -14,6 +14,10 @@
   max-width: calc(100vw - 4em);
   max-height: calc(100vh - 4em);
   overflow: auto;
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%,-50%)
 }
 .modal-header {
   display: flex;


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR

- make modal overlay and modal content siblings instead of parent-child
- default click handler can now differentiate between targets when clicking inside and releasing outside the modal

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Validation

- [x] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/838
