### PR TITLE
Loderunner: Add B3 Trace and Span ID support with OpenTelemetry 

### DIFF
--- a/src/LodeRunner.API/src/Core/Startup.cs
+++ b/src/LodeRunner.API/src/Core/Startup.cs
@@ -25,6 +25,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Prometheus;
 
+using LRCoreSystemConstants = LodeRunner.Core.SystemConstants;
+
 namespace LodeRunner.API
 {
     /// <summary>
@@ -117,8 +119,8 @@ namespace LodeRunner.API
 
             app.Use(async (context, next) =>
             {
-                context.Response.Headers.Add("X-B3-TraceId", Activity.Current.Context.TraceId.ToString());
-                context.Response.Headers.Add("X-B3-SpanId", Activity.Current.Context.SpanId.ToString());
+                context.Response.Headers.Add(LRCoreSystemConstants.XB3TraceIdHeader, Activity.Current.Context.TraceId.ToString());
+                context.Response.Headers.Add(LRCoreSystemConstants.XB3SpanIdHeader, Activity.Current.Context.SpanId.ToString());
 
                 // call next middleware handler
                 await next().ConfigureAwait(false);

--- a/src/LodeRunner.Core/SystemConstants.cs
+++ b/src/LodeRunner.Core/SystemConstants.cs
@@ -209,5 +209,15 @@ namespace LodeRunner.Core
         /// The application will terminate.
         /// </summary>
         public const string ApplicationWillTerminate = "Application will Terminate.";
+
+        /// <summary>
+        /// B3 trace header name.
+        /// </summary>
+        public const string XB3TraceIdHeader = "X-B3-TraceId";
+
+        /// <summary>
+        /// B3 span header name.
+        /// </summary>
+        public const string XB3SpanIdHeader = "X-B3-SpanId";
     }
 }

--- a/src/LodeRunner/LodeRunner.csproj
+++ b/src/LodeRunner/LodeRunner.csproj
@@ -33,6 +33,12 @@
   
     <PackageReference Include="FluentValidation" Version="11.0.2" />
   
+    <PackageReference Include="OpenTelemetry" Version="1.3.0-beta.1" />
+  
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.3" />
+  
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.3" />
+  
     <PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/LodeRunner/src/Program.cs
+++ b/src/LodeRunner/src/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -21,6 +22,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
 
 namespace LodeRunner
 {
@@ -139,6 +142,7 @@ namespace LodeRunner
                 .AddSingleton<CancellationTokenSource>(CancelTokenSource)
                 .AddSingleton<LodeRunnerService>()
                 .AddSingleton<ILodeRunnerService>(provider => provider.GetRequiredService<LodeRunnerService>());
+            Sdk.SetDefaultTextMapPropagator(new B3Propagator());
         }
 
         /// <summary>

--- a/src/LodeRunner/src/ValidationTest/Main.cs
+++ b/src/LodeRunner/src/ValidationTest/Main.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Net.Http;
 using System.Text;
@@ -430,6 +431,14 @@ namespace LodeRunner
 
                 // create correlation vector and add to headers
                 CorrelationVector cv = new(CorrelationVectorVersion.V2);
+
+                // Create b3 traceId and spanId
+                var traceId = ActivityTraceId.CreateRandom().ToString();
+                var spanId = ActivitySpanId.CreateRandom().ToString();
+
+                // Put B3 TraceID and SpanID into request header
+                req.Headers.Add(SystemConstants.XB3TraceIdHeader, traceId);
+                req.Headers.Add(SystemConstants.XB3SpanIdHeader, spanId);
                 req.Headers.Add(CorrelationVector.HeaderName, cv.Value);
 
                 // add the body to the http request
@@ -462,6 +471,8 @@ namespace LodeRunner
                     // add correlation vector to perf log
                     perfLog.CorrelationVector = cv.Value;
                     perfLog.CorrelationVectorBase = cv.GetBase();
+                    perfLog.B3TraceId = traceId;
+                    perfLog.B3SpanId = spanId;
                 }
                 catch (Exception ex)
                 {
@@ -688,6 +699,8 @@ namespace LodeRunner
                     { "ContentLength", perfLog.ContentLength },
                     { "CVector", perfLog.CorrelationVector },
                     { "CVectorBase", perfLog.CorrelationVectorBase },
+                    { "TraceID", perfLog.B3TraceId },
+                    { "SpanID", perfLog.B3SpanId },
                     { "Quartile", perfLog.Quartile },
                     { "Category", perfLog.Category },
                     { SystemConstants.ClientStatusIdFieldName, perfLog.ClientStatusId },

--- a/src/LodeRunner/src/ValidationTest/Model/PerfLog.cs
+++ b/src/LodeRunner/src/ValidationTest/Model/PerfLog.cs
@@ -61,6 +61,16 @@ namespace LodeRunner.Model
         public string CorrelationVectorBase { get; set; }
 
         /// <summary>
+        /// Gets or sets the B3 TraceId for distributed tracing.
+        /// </summary>
+        public string B3TraceId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the B3 SpanId  for distributed tracing.
+        /// </summary>
+        public string B3SpanId { get; set; }
+
+        /// <summary>
         /// Gets the error count.
         /// </summary>
         public int ErrorCount => this.Errors == null ? 0 : this.Errors.Count;


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR

- Add OpenTelemetry library to LodeRunner project
- Generate TraceID and SpanID for each request
- Log the TraceId and SpanID in log

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Validation

- [ ] Unit tests updated and ran successfully
- [X] Update documentation or issue referenced above
- [X] Tested locally (run loderunner and ngsa locally, then match Trace and Span IDs)
- [ ] Tested in a k8s environment
 
## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/803