### PR TITLE
Bugfix: Cosmos Emulator's sleep disorder

### DIFF
--- a/.devcontainer/cosmos-emulator/setup-cosmos-emulator.sh
+++ b/.devcontainer/cosmos-emulator/setup-cosmos-emulator.sh
@@ -11,7 +11,7 @@ mkdir -p "${SSL_CERT_DIR}"
 echo_tee() { echo -e "$@" | tee -a ~/status; }
 
 # wait for the cosmos emulator to start
-echo_tee "  Waiting for CosmosDB Emulator to start"
+echo_tee "  Waiting for CosmosDB emulator to start"
 timeout=120
 while ! test $(docker logs ${COSMOS_EMULATOR_NAME} | grep -vE 'Started ' | grep -E '^Started' | head -n 1)
 do
@@ -29,9 +29,21 @@ cat /etc/hosts | grep "documents.azure.com" || echo "127.0.0.1  ${COSMOS_EMULATO
 # Copy emulator cert to ssl dir
 if [[ ! -f ${NGINX_CONFIG_PATH}/emulatorcert.crt || "$(cat ${NGINX_CONFIG_PATH}/emulatorcert.crt | grep 'CERTIFICATE')" == '' ]]; then
     sleep 5
-    echo_tee "  Emulator Cert doesn't exist"
+    echo_tee "  Emulator cert doesn't exist. Downloading again."
     curl -k "https://127.0.0.1:9090/_explorer/emulator.pem" >| "${NGINX_CONFIG_PATH}/emulatorcert.crt"
 fi
 
 cp "${NGINX_CONFIG_PATH}/${COSMOS_EMULATOR_NAME}.crt" "${SSL_CERT_DIR}/${COSMOS_EMULATOR_NAME}.pem"
 cp "${NGINX_CONFIG_PATH}/emulatorcert.crt" "${SSL_CERT_DIR}/emulatorcert.pem"
+
+echo_tee "  Removing old certificates"
+sudo rm /usr/local/share/ca-certificates/${COSMOS_EMULATOR_NAME}.* /usr/share/ca-certificates/${COSMOS_EMULATOR_NAME}.* /etc/ssl/certs/${COSMOS_EMULATOR_NAME}.*
+
+sudo update-ca-certificates
+sudo find -L /etc/ssl/certs/ -maxdepth 1 -type l -delete
+
+echo_tee "  Adding generated cert to ca-certificates"
+sudo cp "${NGINX_CONFIG_PATH}/${COSMOS_EMULATOR_NAME}.crt" /usr/local/share/ca-certificates/
+sudo cp "${NGINX_CONFIG_PATH}/emulatorcert.crt" /usr/share/ca-certificates/
+
+sudo update-ca-certificates


### PR DESCRIPTION
# Type of PR

- [X] Code changes

## PR Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR

When resuming codespace, cosmos emulator doesn't find the certificate.

Because the certificate sometimes gets deleted after prolonged codespace sleep, it needs to be installed again.



## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/844