### PR TITLE
Run MDLint on PRs only 

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,6 +1,12 @@
 name: markdownlint
 
-on: [push, pull_request]
+on:
+  pull_request:
+      types: [opened, synchronize]
+
+  push:
+    branches:
+      - main
 
 jobs:
   markdown-linter:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# SOME CHANGES
 # loderunner
 
 - [LodeRunner](./src/LodeRunner/README.md) is the load client that waits for TestRun entries in CosmosDB, and execute those load tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# SOME CHANGES
 # loderunner
 
 - [LodeRunner](./src/LodeRunner/README.md) is the load client that waits for TestRun entries in CosmosDB, and execute those load tests


### PR DESCRIPTION
# Type of PR

- [X] CI-CD changes

## Purpose of PR

Currently MDLint check runs on all branches on push.

Markdown Lint Action should only run for
- Pull Request [Open, Synchronize]
- Push/Merge on `main`

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Validation

- [X] Verified MDLint runs on all branches on push
- [x] Verified with a PR that it runs on open and sync

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/842