### PR TITLE
LodeRunner.UI - Fix Lint Rules Conflict

### DIFF
--- a/src/LodeRunner.UI/package-lock.json
+++ b/src/LodeRunner.UI/package-lock.json
@@ -3683,7 +3683,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "@types/mime": {
       "version": "1.3.2",

--- a/src/LodeRunner.UI/package.json
+++ b/src/LodeRunner.UI/package.json
@@ -21,7 +21,7 @@
     "whatwg-fetch": "^3.6.2"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",
     "build-prod": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "build": "react-scripts build",
     "test": "jest",


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
LodeRunner.UI linter had conflict about where to pull from. disabling eslint plugin when starting application so it can pull from airbnb rules instead.

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/52010147/175142206-ff544568-044e-4da4-9b64-62f651b5c3fa.png">

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/852
