### PR TITLE
Move Cosmos Emulator setup to onCreate for Prebuild

### DIFF
--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -10,4 +10,28 @@ docker network create k3d
 k3d registry create registry.localhost --port 5000
 docker network connect k3d k3d-registry.localhost
 
+# update packages
+sudo apt-get update
+
+# start CosmosDB Emulator & setup nginx
+echo "  Build CosmosDB Emulator & nginx" | tee -a ~/status
+sudo ./$(dirname $0)/cosmos-emulator/start-cosmos-emulator.sh
+
+# get install script and install node
+# [Choice] Node.js version: 16, 14, 12
+echo "  Install NodeJS" | tee -a ~/status
+VARIANT=14
+curl -sL https://deb.nodesource.com/setup_${VARIANT}.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# install client dependencies
+pushd src/LodeRunner.UI
+echo "  Install NodeJS packages for LodeRunner.UI" | tee -a ~/status
+npm install
+detach
+popd
+
+# install Azure Cosmos SDK
+pip3 install azure-cosmos
+
 echo "on-create complete" >> ~/status

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,33 +3,4 @@
 set -m # Turn on Bash Job control
 echo "post-create start" >> ~/status
 
-# this runs in background after UI is available
-
-# (optional) upgrade packages
-sudo apt-get update
-# sudo apt-get upgrade -y
-#sudo apt-get autoremove -y
-#sudo apt-get clean -y
-
-# start CosmosDB Emulator & setup nginx
-echo "  build CosmosDB Emulator & nginx" | tee -a ~/status
-sudo ./$(dirname $0)/cosmos-emulator/start-cosmos-emulator.sh
-
-# get install script and install node
-# [Choice] Node.js version: 16, 14, 12
-echo "  Install NodeJS" | tee -a ~/status
-VARIANT=14
-curl -sL https://deb.nodesource.com/setup_${VARIANT}.x | sudo -E bash -
-sudo apt-get install -y nodejs
-
-# install client dependencies
-pushd src/LodeRunner.UI
-echo "  Install NodeJS packages for LodeRunner.UI" | tee -a ~/status
-npm install
-detach
-popd
-
-# install Azure Cosmos SDK
-pip3 install azure-cosmos
-# wait on the CosmosDB Emulator script
 echo "post-create complete" >> ~/status


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
To move the cosmos emulator create script to onCreate to enable Codespaces prebuild

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Validation

- [x] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/855
