### PR TITLE
Removed CRLF configuration from editorconfig

### DIFF
--- a/src/LodeRunner.API/src/.editorconfig
+++ b/src/LodeRunner.API/src/.editorconfig
@@ -9,7 +9,6 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
 insert_final_newline = true
 
 #### .NET Coding Conventions ####

--- a/src/LodeRunner/src/.editorconfig
+++ b/src/LodeRunner/src/.editorconfig
@@ -9,7 +9,6 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
 insert_final_newline = true
 
 #### .NET Coding Conventions ####


### PR DESCRIPTION
# Type of PR

- [X] Code changes

## Purpose of PR
Remove CRLF configuration which is missing from the line ending PR.

With this change, VSCode will not convert the line ending to CRLF automatically.

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Validation

- [X] Unit tests updated and ran successfully
- [X] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/874