### PR TITLE
BugFix - Remove ParentSpanID from LodeRunner

### DIFF
--- a/src/LodeRunner/src/ValidationTest/Main.cs
+++ b/src/LodeRunner/src/ValidationTest/Main.cs
@@ -470,7 +470,6 @@ namespace LodeRunner
                     // add tracing IDs to perf log
                     perfLog.B3TraceId = traceId;
                     perfLog.B3SpanId = spanId;
-                    perfLog.B3ParentSpanId = spanId;
                 }
                 catch (Exception ex)
                 {
@@ -697,7 +696,6 @@ namespace LodeRunner
                     { "ContentLength", perfLog.ContentLength },
                     { SystemConstants.B3TraceIdFieldName, perfLog.B3TraceId },
                     { SystemConstants.B3SpanIdFieldName, perfLog.B3SpanId },
-                    { SystemConstants.B3ParentSpanIdFieldName, perfLog.B3ParentSpanId },
                     { "Quartile", perfLog.Quartile },
                     { "Category", perfLog.Category },
                     { SystemConstants.ClientStatusIdFieldName, perfLog.ClientStatusId },

--- a/src/LodeRunner/src/ValidationTest/Model/PerfLog.cs
+++ b/src/LodeRunner/src/ValidationTest/Model/PerfLog.cs
@@ -61,11 +61,6 @@ namespace LodeRunner.Model
         public string B3SpanId { get; set; }
 
         /// <summary>
-        /// Gets or sets the B3 ParentSpanId  for distributed tracing.
-        /// </summary>
-        public string B3ParentSpanId { get; set; }
-
-        /// <summary>
         /// Gets the error count.
         /// </summary>
         public int ErrorCount => this.Errors == null ? 0 : this.Errors.Count;


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
ParentSpanID is not required to be logged in LodeRunner as it originates requests and does not having parent tracing information.

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- References https://github.com/retaildevcrews/wcnp/issues/882
- Closes https://github.com/retaildevcrews/wcnp/issues/925