### PR TITLE
LR.UI Bug - RunLoop always shows false when view a config

### DIFF
--- a/src/LodeRunner.UI/src/components/ConfigPage/index.js
+++ b/src/LodeRunner.UI/src/components/ConfigPage/index.js
@@ -24,24 +24,24 @@ const ConfigPage = ({ configId }) => {
   const tagFlagRef = useRef();
   const timeoutFlagRef = useRef();
 
+  // declare boolean references
+  const dryRunFlagRef = useRef();
+  const randomizeFlagRef = useRef();
+  const runLoopFlagRef = useRef();
+  const strictJsonFlagRef = useRef();
+  const verboseErrorsFlagRef = useRef();
+
   // handle boolean input references
-  const dryRunFlagRef = useRef(
-    openedConfig?.[CONFIG.dryRun] ?? CONFIG_OPTIONS[CONFIG.dryRun].default
-  );
-  const randomizeFlagRef = useRef(
-    openedConfig?.[CONFIG.randomize] ?? CONFIG_OPTIONS[CONFIG.randomize].default
-  );
-  const runLoopFlagRef = useRef(
-    openedConfig?.[CONFIG.runLoop] ?? CONFIG_OPTIONS[CONFIG.runLoop].default
-  );
-  const strictJsonFlagRef = useRef(
-    openedConfig?.[CONFIG.strictJson] ??
-      CONFIG_OPTIONS[CONFIG.strictJson].default
-  );
-  const verboseErrorsFlagRef = useRef(
-    openedConfig?.[CONFIG.verboseErrors] ??
-      CONFIG_OPTIONS[CONFIG.verboseErrors].default
-  );
+  dryRunFlagRef.current =
+    openedConfig?.[CONFIG.dryRun] ?? CONFIG_OPTIONS[CONFIG.dryRun].default;
+  randomizeFlagRef.current =
+    openedConfig?.[CONFIG.randomize] ?? CONFIG_OPTIONS[CONFIG.randomize].default;
+  runLoopFlagRef.current =
+    openedConfig?.[CONFIG.runLoop] ?? CONFIG_OPTIONS[CONFIG.runLoop].default;
+  strictJsonFlagRef.current =
+    openedConfig?.[CONFIG.strictJson] ?? CONFIG_OPTIONS[CONFIG.strictJson].default;
+  verboseErrorsFlagRef.current =
+    openedConfig?.[CONFIG.verboseErrors] ?? CONFIG_OPTIONS[CONFIG.verboseErrors].default;
 
   useEffect(() => {
     setIsPending(true);


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
Fixes an issue when viewing/editing a Load Test Config where boolean inputs in the form default to false instead of loading appropriate value.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [x] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/1002
