### PR TITLE
Parameterized keyvault names in loderunner-pod-identity.yaml autogitops template

### DIFF
--- a/autogitops/dev/loderunner-pod-identity.yaml
+++ b/autogitops/dev/loderunner-pod-identity.yaml
@@ -52,7 +52,7 @@ spec:
       key: key
   parameters:
     usePodIdentity: "true"
-    keyvaultName: "kv-aks-3i2qzkkxofr7c"
+    keyvaultName: {{gitops.keyvaultName}}
     objects: |
       array:
         - |

--- a/autogitops/preprod/loderunner-pod-identity.yaml
+++ b/autogitops/preprod/loderunner-pod-identity.yaml
@@ -52,7 +52,7 @@ spec:
       key: key
   parameters:
     usePodIdentity: "true"
-    keyvaultName: "kv-aks-fykg5bqasutle"
+    keyvaultName: {{gitops.keyvaultNamePreprod}}
     objects: |
       array:
         - |


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [x] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
<!-- Concise description of the problem and the solution or the feature being added -->

Updating gitops templates to remove hardcoded keyvault names. Keyvault names from old subscription were hardcoded in autogitops template, causing loderunner to fail in new subscription.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes retaildevcrews/wcnp/issues/1117
- Closes #326 
- References retaildevcrews/wcnp/issues/1028
- References retaildevcrews/wcnp/issues/1055
